### PR TITLE
fix: update new org name

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,7 +12,7 @@ then
 fi
 
 # Define variables
-REPO_NAME=https://github.com/GilAddaCyberark/crypto-scanner/
+REPO_NAME=https://github.com/hub-adda/crypto-scanner/
 REPO_DIR=crypto-scanner
 BRANCH=main
 SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )


### PR DESCRIPTION
The old name reference, while now is redirecting, is potentially susceptible in the future to issues like repo jacking on GitHub.

Better to keep the org/user references up to date :-)